### PR TITLE
Some cosmetic:

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -1,58 +1,54 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: OpenPLi Quad PiP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-10 23:58+0300\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"POT-Creation-Date: 2018-12-27 14:39+0100\n"
+"PO-Revision-Date: \n"
+"Last-Translator: ims <ims21@users.sourceforge.net>\n"
+"Language-Team: PLi <ims@openpli.org>\n"
+"Language: cs_CZ\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 1.8.7.1\n"
 
 #: qpip.py:636
 msgid "  Menu key : Select quad channel"
-msgstr ""
+msgstr "menu - výběr Quad seznamu"
 
 #: qpip.py:635
 msgid "  Red key : Show/Hide texts"
-msgstr ""
+msgstr "red - zobrazit/skrýt texty"
 
 #: qpip.py:534
 msgid " (current channel)"
-msgstr ""
+msgstr " (aktuální­)"
 
 #: qpip.py:72
 msgid " <No Channel>"
-msgstr ""
+msgstr " <žádný program>"
 
 #: qpip.py:284
 msgid " <empty>"
-msgstr ""
+msgstr " <prázdný>"
 
 #: qpip.py:433
 msgid "Add"
-msgstr ""
+msgstr "Přidat"
 
 #: qpip.py:443
 msgid "Add New Quad Channel Entry"
-msgstr ""
+msgstr "Přidat nový Quad seznam"
 
 #: qpip.py:670
 msgid "Box or driver is not support Quad PiP."
-msgstr ""
+msgstr "Přijímač nebo ovladač nepodporují­ Quad PiP."
 
 #: qpip.py:332
 #, python-format
 msgid "Choice where to put \"%s\""
-msgstr ""
+msgstr "Vyberte, kam vložit \"%s\""
 
 #: qpip.py:269
 msgid ""
@@ -61,6 +57,10 @@ msgid ""
 "PVR key : Input channel name\n"
 "Exit key : Finish channel edit"
 msgstr ""
+"EPG - přepnout do programů\n"
+"OK - odstranit program\n"
+"PVR - přejmenovat Quad seznam\n"
+"Exit - ukončit úpravy"
 
 #: qpip.py:267
 msgid ""
@@ -69,46 +69,50 @@ msgid ""
 "PVR key : Input channel name\n"
 "Exit key : Finish channel edit"
 msgstr ""
+"EPG - přepnout do Quad seznamu\n"
+"OK - přidat program\n"
+"PVR - přejmenovat Quad seznam\n"
+"Exit - ukončit úpravy"
 
 #: qpip.py:435
 msgid "Edit"
-msgstr ""
+msgstr "Upravit"
 
 #: qpip.py:445
 msgid "Edit Quad Channel Entry"
-msgstr ""
+msgstr "Upravit položky Quad seznamu"
 
 #: plugin.py:17
 msgid "Enable Quad PiP"
-msgstr ""
+msgstr "Povolit Quad PIP"
 
 #: qpip.py:451
 msgid "Exit Quad Channel Selection"
-msgstr ""
+msgstr "Zavřít výběr Quad seznamů"
 
 #: qpip.py:617
 msgid "Exit quad PiP"
-msgstr ""
+msgstr "Zavřít Quad PiP"
 
 #: qpip.py:258
 msgid "Input channel name."
-msgstr ""
+msgstr "Název seznamu"
 
 #: qpip.py:627
 msgid "Next quad PiP channel"
-msgstr ""
+msgstr "Další­ Quad PiP seznam"
 
 #: qpip.py:936
 msgid "No channel"
-msgstr ""
+msgstr "Žádný seznam"
 
 #: qpip.py:626
 msgid "Prev quad PiP channel"
-msgstr ""
+msgstr "Předchozí­ Quad PiP seznam"
 
 #: qpip.py:404
 msgid "Quad PiP Channel Selection"
-msgstr ""
+msgstr "Quad PiP - výběr seznamu"
 
 #: qpip.py:612
 msgid "Quad PiP Screen"
@@ -116,7 +120,7 @@ msgstr ""
 
 #: qpip.py:116
 msgid "Quad PiP channel "
-msgstr ""
+msgstr "Quad PiP seznam "
 
 #: qpip.py:667
 msgid "Quad PiP is not available."
@@ -128,36 +132,36 @@ msgstr ""
 
 #: qpip.py:483
 msgid "Really delete this entry?"
-msgstr ""
+msgstr "Opravdu odstranit seznam?"
 
 #: qpip.py:434
 msgid "Remove"
-msgstr ""
+msgstr "Smazat"
 
 #: qpip.py:444
 msgid "Remove Quad Channel Entry"
-msgstr ""
+msgstr "Smazat Quad seznam"
 
 #: qpip.py:432
 msgid "Select"
-msgstr ""
+msgstr "Vybrat"
 
 #: qpip.py:442 qpip.py:450
 msgid "Select Quad Channels"
-msgstr ""
+msgstr "Vybrat Quad seznamy"
 
 #: qpip.py:619 qpip.py:620 qpip.py:621 qpip.py:622
 msgid "Select channel audio"
-msgstr ""
+msgstr "Výběr zvuku programu"
 
 #: qpip.py:623 qpip.py:624 qpip.py:625
 msgid "Show channel selection"
-msgstr ""
+msgstr "Zobrazit výběr seznamů"
 
 #: qpip.py:628
 msgid "Show/Hide focus bar"
-msgstr ""
+msgstr "Zobrazit/skrýt výběr"
 
 #: qpip.py:618
 msgid "Zap focused channel on full screen"
-msgstr ""
+msgstr "Přepnout zvolený program na celou obrazovku"

--- a/po/fr.po
+++ b/po/fr.po
@@ -16,7 +16,7 @@ msgid "  Menu key : Select quad channel"
 msgstr "  Touche Menu : Sélectionner le canal quadruple"
 
 #: ../qpip.py:638
-msgid "  Red key : Show/Hide channel name"
+msgid "  Red key : Show/Hide texts"
 msgstr "  Touche rouge : Afficher/Masquer le nom du canal"
 
 #: ../qpip.py:537

--- a/po/ru.po
+++ b/po/ru.po
@@ -16,7 +16,7 @@ msgstr ""
 msgid "  Menu key : Select quad channel"
 msgstr "[menu]: Выбор блока Quad"
 
-msgid "  Red key : Show/Hide channel name"
+msgid "  Red key : Show/Hide texts"
 msgstr "[red]: Скрыть/показать текст"
 
 msgid " (current channel)"

--- a/qpip.py
+++ b/qpip.py
@@ -415,23 +415,23 @@ class QuadPiPChannelSelection(Screen, HelpableScreen):
 		list_y = 40+button_margin*3
 		self.fontSize = {1080:(28, 24), 720:(24,20), 576:(20,18)}.get(dh, (28, 24))
 		self.skin = QuadPiPChannelSelection.skin % (pw, ph, \
-														sw, sh+list_y, \
-														sw/8-70, button_margin, \
-														sw/8-70+sw/4, button_margin, \
-														sw/8-70+sw/4*2, button_margin, \
-														sw/8-70+sw/4*3, button_margin, \
-														sw/8-70, button_margin, \
-														sw/8-70+sw/4, button_margin, \
-														sw/8-70+sw/4*2, button_margin, \
-														sw/8-70+sw/4*3, button_margin, \
-														0, list_y, sw, sh, \
-														sw/16, 1, sw-sw/16*2, sh/13, \
-														sw/11, 1+sh/13, 			sw-sw/16*2-sw/8, sh/18, \
-														sw/11, 1+sh/13+sh/18, 	sw-sw/16*2-sw/8, sh/18, \
-														sw/11, 1+sh/13+sh/18*2, 	sw-sw/16*2-sw/8, sh/18, \
-														sw/11, 1+sh/13+sh/18*3, 	sw-sw/16*2-sw/8, sh/18, \
-														self.fontSize[0], self.fontSize[1], \
-														sh/3)
+								sw, sh+list_y, \
+								sw/8-70, button_margin, \
+								sw/8-70+sw/4, button_margin, \
+								sw/8-70+sw/4*2, button_margin, \
+								sw/8-70+sw/4*3, button_margin, \
+								sw/8-70, button_margin, \
+								sw/8-70+sw/4, button_margin, \
+								sw/8-70+sw/4*2, button_margin, \
+								sw/8-70+sw/4*3, button_margin, \
+								0, list_y, sw, sh, \
+								sw/16, 1, sw-sw/16*2, sh/13, \
+								sw/11, 1+sh/13, sw-sw/16*2-sw/8, sh/18, \
+								sw/11, 1+sh/13+sh/18, sw-sw/16*2-sw/8, sh/18, \
+								sw/11, 1+sh/13+sh/18*2, sw-sw/16*2-sw/8, sh/18, \
+								sw/11, 1+sh/13+sh/18*3, sw-sw/16*2-sw/8, sh/18, \
+								self.fontSize[0], self.fontSize[1], \
+								sh/3)
 		self["key_red"] = Label(_("Select"))
 		self["key_green"] = Label(_("Add"))
 		self["key_yellow"] = Label(_("Remove"))
@@ -603,7 +603,7 @@ class QuadPipScreen(Screen, FocusShowHide, HelpableScreen):
 			<widget name="ch4" position="1200,780" zPosition="1" size="480,60" font="Regular; %d" halign="center" valign="center" foregroundColor="white" backgroundColor="#ffffffff" alphatest="on" borderWidth="2"/>
 			<widget name="text1" position="%d,%d" zPosition="2" size="%d,%d" font="Regular; %d" halign="left" valign="center" foregroundColor="white" backgroundColor="#ffffffff" alphatest="on" borderWidth="2"/>
 			<widget name="text2" position="%d,%d" zPosition="2" size="%d,%d" font="Regular; %d" halign="left" valign="center" foregroundColor="white" backgroundColor="#ffffffff" alphatest="on" borderWidth="2"/>
-			<widget name="focus" position="0,0" zPosition="-1" size="960,540" backgroundColor="#ffffffff" borderWidth="5" borderColor="#e61616" alphatest="on" />
+			<widget name="focus" position="0,0" zPosition="3" size="960,540" backgroundColor="#ffffffff" borderWidth="5" borderColor="#e61616" transparent="1" alphatest="on" />
 		</screen>
 		"""
 	def __init__(self, session):
@@ -635,7 +635,7 @@ class QuadPipScreen(Screen, FocusShowHide, HelpableScreen):
 		self["ch2"] = Label(" ")
 		self["ch3"] = Label(" ")
 		self["ch4"] = Label(" ")
-		self["text1"] = Label(_("  Red key : Show/Hide channel name"))
+		self["text1"] = Label(_("  Red key : Show/Hide texts"))
 		self["text2"] = Label(_("  Menu key : Select quad channel"))
 		self["focus"] = Slider(-1, -1)
 
@@ -643,9 +643,9 @@ class QuadPipScreen(Screen, FocusShowHide, HelpableScreen):
 		self.updatePositionList()
 
 		self.skin = QuadPipScreen.skin % (self.session.desktop.size().width(), self.session.desktop.size().height(), \
-												self.fontSize, self.fontSize, self.fontSize, self.fontSize, \
-												self.text1Pos[0], self.text1Pos[1], self.text1Pos[2], self.text1Pos[3], self.fontSize, \
-												self.text2Pos[0], self.text2Pos[1], self.text2Pos[2], self.text2Pos[3], self.fontSize)
+							self.fontSize, self.fontSize, self.fontSize, self.fontSize, \
+							self.text1Pos[0], self.text1Pos[1]-5, self.text1Pos[2], self.text1Pos[3], self.fontSize, \
+							self.text2Pos[0], self.text2Pos[1]-5, self.text2Pos[2], self.text2Pos[3], self.fontSize)
 		self.oldService = None
 		self.curChannel = None
 		self.curPlayAudio = -1


### PR DESCRIPTION
- changed large text 'Show/Hide channel name' to 'Show/Hide texts'. Updated in .pot and .po too
- remove several tabs
Fixed focus rectangle:
- help texts on main screen moved 5 pixels up
- focus rectangle z-position from -1 to 3 and set it as transparent (no more replaced with text labels)
Added cs translate