### PR TITLE
Fix pickle for python3

### DIFF
--- a/plugin/qpip.py
+++ b/plugin/qpip.py
@@ -95,14 +95,14 @@ class QuadPipChannelData:
 		self.dataLoad()
 
 	def dataSave(self):
-		fd = open(self.pipChannelDataPath, "w")
+		fd = open(self.pipChannelDataPath, "wb")
 		pickle.dump(self.PipChannelList, fd)
 		fd.close()
 
 	def dataLoad(self):
 		if not os.access(self.pipChannelDataPath, os.R_OK):
 			return
-		fd = open(self.pipChannelDataPath, "r")
+		fd = open(self.pipChannelDataPath, "rb")
 		self.PipChannelList = pickle.load(fd)
 		fd.close()
 


### PR DESCRIPTION
pickle works with bytes, not text strings. This change should be python2 compatible as well

This fixes https://github.com/OpenPLi/openpli-oe-core/commit/a4703f4814275cb7960812253d04fb0f27939b5a